### PR TITLE
Ensure PATCH requests require a field

### DIFF
--- a/openapi/todo.yaml
+++ b/openapi/todo.yaml
@@ -115,6 +115,7 @@ components:
         completed: { type: boolean, default: false }
     TodoPatch:
       type: object
+      minProperties: 1
       properties:
         title: { type: string, minLength: 1 }
         completed: { type: boolean }


### PR DESCRIPTION
## Summary
- require at least one property in the `TodoPatch` schema so PATCH requests cannot send empty objects

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce19bcf060832b84e7af04e66421ce